### PR TITLE
Add Google OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ playwright install
   GOOGLE_API_KEY=YOUR_GEMINI_API_KEY
   ```
   Replace `YOUR_GEMINI_API_KEY` with your actual key.
+- **Google OAuth Credentials** for login:
+  ```ini
+  GOOGLE_CLIENT_ID=YOUR_GOOGLE_CLIENT_ID
+  GOOGLE_CLIENT_SECRET=YOUR_GOOGLE_CLIENT_SECRET
+  FLASK_SECRET_KEY=some_random_secret
+  ```
 
 #### Optional:
 
@@ -63,11 +69,11 @@ playwright install
 
 ### Running the Web UI
 
-1. Navigate to the repository directory:
+1. Navigate to the repository directory and start the server:
    ```bash
-   python web_ui.py
+   python app.py
    ```
-2. Open a browser and go to the displayed address (e.g., `http://127.0.0.1:7788`).
+2. You will be redirected to a Google login page. After signing in, you will be sent to the Gradio interface (by default at `http://127.0.0.1:7788`).
 3. Use the **Web UI** to:
    - Configure **agent settings**, **LLM parameters**, and **browser options**.
    - Enter a task description and optional hints.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,82 @@
+import os
+from flask import Flask, redirect, url_for, session, render_template_string
+from authlib.integrations.flask_client import OAuth
+from dotenv import load_dotenv
+
+from src.utils.default_config_settings import default_config
+from web_ui import create_ui
+from gradio import mount_gradio_app
+
+load_dotenv()
+
+app = Flask(__name__)
+app.secret_key = os.getenv("FLASK_SECRET_KEY", "change-me")
+app.config['SESSION_COOKIE_NAME'] = 'browseruse_session'
+
+oauth = OAuth(app)
+
+oauth.register(
+    name='google',
+    client_id=os.getenv('GOOGLE_CLIENT_ID'),
+    client_secret=os.getenv('GOOGLE_CLIENT_SECRET'),
+    access_token_url='https://accounts.google.com/o/oauth2/token',
+    access_token_params=None,
+    authorize_url='https://accounts.google.com/o/oauth2/auth',
+    authorize_params=None,
+    api_base_url='https://www.googleapis.com/oauth2/v1/',
+    userinfo_endpoint='https://www.googleapis.com/oauth2/v1/userinfo',
+    client_kwargs={'scope': 'openid email profile'}
+)
+
+
+def login_required(func):
+    from functools import wraps
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'google_token' not in session:
+            return redirect(url_for('login'))
+        return func(*args, **kwargs)
+    return wrapper
+
+
+@app.route('/')
+def index():
+    if 'google_token' in session:
+        return redirect(url_for('gradio_app'))
+    return render_template_string('<a href="{{ url_for("login") }}">Login with Google</a>')
+
+
+@app.route('/login')
+def login():
+    redirect_uri = url_for('authorize', _external=True)
+    return oauth.google.authorize_redirect(redirect_uri)
+
+
+@app.route('/authorize')
+def authorize():
+    token = oauth.google.authorize_access_token()
+    session['google_token'] = token
+    resp = oauth.google.get('userinfo')
+    session['user'] = resp.json()
+    return redirect(url_for('gradio_app'))
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('index'))
+
+
+demo = create_ui(default_config())
+mount_gradio_app(app, demo, path="/ui")
+
+
+@app.route('/app')
+@login_required
+def gradio_app():
+    return redirect('/ui')
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=int(os.getenv('PORT', 7788)))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ pyperclip
 pytest
 google.genai
 pyautogui
+flask
+authlib


### PR DESCRIPTION
## Summary
- implement `app.py` with Google OAuth login using Flask and Authlib
- mention OAuth env vars in README and how to run `app.py`
- add Flask and Authlib to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ClientError INVALID_ARGUMENT, BrowserType.launch_persistent_context EACCES)*

------
https://chatgpt.com/codex/tasks/task_e_6841490c4e50832d8d4c0339836d2350